### PR TITLE
Reset Trip Status on Date Change

### DIFF
--- a/app/controllers/FieldTrip.java
+++ b/app/controllers/FieldTrip.java
@@ -540,6 +540,10 @@ public class FieldTrip extends Application {
                 trip.delete();
             }
             renderJSON(requestId);
+
+            // Need to reset trip status when request date changes
+            req.outboundTripStatus = null;
+            req.inboundTripStatus = null;
         }
         else {
             badRequest();


### PR DESCRIPTION
The date change functionality did not reset the inbound or outbound trip status. This had the effect of trip status saying a trip was planned when that trip either didn't exist or was for a different day! This PR resolves this by resetting inbound and outbound trip status whenever the date is changed.