### PR TITLE
fix: prevent calling find (db query) w/null values 

### DIFF
--- a/app/controllers/FieldTrip.java
+++ b/app/controllers/FieldTrip.java
@@ -205,8 +205,11 @@ public class FieldTrip extends Application {
         for(int i = 0; i < itins.length; i++) {
             GroupItinerary itin = itins[i];
             for(GTFSTrip gtrip : gtfsTrips[i]) {
+                // sending a 'null' value to find("tripHash = ?") w/postgres causes type errors
+		// @see: https://stackoverflow.com/questions/63971110
+                if(gtrip.tripHash == null) continue;
+
                 List<GTFSTrip> tripsInUse = GTFSTrip.find("tripHash = ?", gtrip.tripHash).fetch();
-                
                 if(!tripsInUse.isEmpty()) {
                     int capacityInUse = 0;
                     for(GTFSTrip tripInUse : tripsInUse) {

--- a/app/controllers/FieldTrip.java
+++ b/app/controllers/FieldTrip.java
@@ -206,8 +206,11 @@ public class FieldTrip extends Application {
             GroupItinerary itin = itins[i];
             for(GTFSTrip gtrip : gtfsTrips[i]) {
                 // sending a 'null' value to find("tripHash = ?") w/postgres causes type errors
-		// @see: https://stackoverflow.com/questions/63971110
-                if(gtrip.tripHash == null) continue;
+                // @see: https://stackoverflow.com/questions/63971110
+                if(gtrip.tripHash == null) {
+                    System.out.println("WARN: fieldtrips might get double-booked. With tripHash == null, overlapping/duplicate fieldtrip integrity check is bypassed.");
+                    continue;
+                }
 
                 List<GTFSTrip> tripsInUse = GTFSTrip.find("tripHash = ?", gtrip.tripHash).fetch();
                 if(!tripsInUse.isEmpty()) {
@@ -411,7 +414,7 @@ public class FieldTrip extends Application {
         
         //if(cal.after(now)) return true;
         
-        return true;	
+        return true;
     }
 
     public static void getRequest(long requestId) {


### PR DESCRIPTION
This PR adds a check for null on gtrip.tripHash, prior to querying the db.
This check is important with Postgres, since null values will throw errors when gtrip.tripHash is null on the following statement:  GTFSTrip.find("tripHash = ?", gtrip.tripHash).fetch();
see: https://stackoverflow.com/questions/63971110/query-resulting-into-error-operator-does-not-exist-character-varying-bytea

Questions for OTP-RR devs:
 - why is gtrip.tripHash suddenly getting null values with OTP 2.x + new call (e.g., don't think we've seen gtrip.tripHash have null values till recently, or else the Play! code that's in production would have surfaced this find() using null problem years ago with OTP 1.x and old calltaker?
 - what does it mean for the integrity of the fieldtrips if the gtrip.tripHash code never executes because of we're getting null tripHash values?  (could multiple fieldtrips book the same vehicles?)